### PR TITLE
Update configurations for re-publishing as scoped module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: "Re-publish as scoped module"
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check scope
+        run: |
+          if ! grep -q '@cto.ai/dockerode' package.json; then
+            echo '@cto.ai/dockerode not found in package.json file'
+            exit 1
+          fi
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: npm install
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ cookbooks
 test
 tools
 examples
+.github

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE**: This is an [apocas/dockerode](https://github.com/apocas/dockerode) unofficial fork. Please refer to that node package home page for questions or issues.
+
 # dockerode [![Build Status](https://travis-ci.org/apocas/dockerode.svg?branch=master)](https://travis-ci.org/apocas/dockerode)
 
 Not another Node.js Docker Remote API module.

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
-  "name": "dockerode",
+  "name": "@cto.ai/dockerode",
   "description": "Docker Remote API module.",
   "version": "3.2.1",
   "author": "Pedro Dias <petermdias@gmail.com>",
-  "maintainers": [
-    "apocas <petermdias@gmail.com>"
-  ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/apocas/dockerode.git"
+    "url": "https://github.com/cto-ai/dockerode.git"
   },
   "keywords": [
     "docker",
@@ -32,5 +29,8 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8.0"
+  },
+  "directories": {
+    "lib": "lib"
   }
 }


### PR DESCRIPTION
I have updated the required npm configurations to republish `dockerode@3.2.1` as a `@cto.ai` scoped module **publicly**. 

From license liability perspective, we can modify and redistribute the source code. We could even re-license it if we truly would like to go down that path. This [official Apache License FAQ](https://www.apache.org/foundation/license-faq.html) has plain-English compilation of what we can do or not with it.

The lingering question if we want pursue the automation route, adding the GH workflows to handle the publish process, or can we table it as an "one of" manual release then following up with the upstream `dockerode` patch aftewards?   